### PR TITLE
Fixed Require for google-api-php-client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.*",
-        "google/apiclient": "dev-master"
+        "google/google-api-php-client": "dev-master"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Not sure if this fixes the install issue, but google/apiclient doesn't exist....
